### PR TITLE
fix: use ubuntu 18.04 nmcli parameters

### DIFF
--- a/wireless/Wireless.py
+++ b/wireless/Wireless.py
@@ -3,7 +3,7 @@ import subprocess
 from time import sleep
 from packaging import version
 import re
-
+import lsb_release
 
 # send a command to the shell and return the result
 def cmd(cmd):
@@ -11,6 +11,14 @@ def cmd(cmd):
         cmd, shell=True,
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     ).stdout.read().decode()
+
+
+def get_nmcli_if_param():
+    main_version = int(lsb_release.get_lsb_information()['DESCRIPTION'].split()[1][0:2])
+    if main_version >= 18:
+        return 'ifname'
+    else:
+        return 'iface'
 
 
 # abstracts away wireless connection
@@ -159,8 +167,8 @@ class NmcliWireless(WirelessDriver):
         self._clean(self.current())
 
         # attempt to connect
-        response = cmd('nmcli dev wifi connect {} password {} iface {}'.format(
-            ssid, password, self._interface))
+        response = cmd('nmcli dev wifi connect {} password {} {} {}'.format(
+            ssid, password, get_nmcli_if_param(), self._interface))
 
         # parse response
         return not self._errorInResponse(response)
@@ -256,8 +264,8 @@ class Nmcli0990Wireless(WirelessDriver):
         self._clean(self.current())
 
         # attempt to connect
-        response = cmd('nmcli dev wifi connect {} password {} iface {}'.format(
-            ssid, password, self._interface))
+        response = cmd('nmcli dev wifi connect {} password {} {} {}'.format(
+            ssid, password, get_nmcli_if_param(), self._interface))
 
         # parse response
         return not self._errorInResponse(response)

--- a/wireless/Wireless.py
+++ b/wireless/Wireless.py
@@ -3,7 +3,7 @@ import subprocess
 from time import sleep
 from packaging import version
 import re
-import lsb_release
+
 
 # send a command to the shell and return the result
 def cmd(cmd):
@@ -14,7 +14,9 @@ def cmd(cmd):
 
 
 def get_nmcli_if_param():
-    main_version = int(lsb_release.get_lsb_information()['DESCRIPTION'].split()[1][0:2])
+    with open('/etc/lsb-release') as f:
+        data = f.read()
+        main_version = int(re.search('(?<=RELEASE=)[0-9]+', data).group(0))
     if main_version >= 18:
         return 'ifname'
     else:


### PR DESCRIPTION
# Description
iface parameter is valid for older versions of nmcli but not new ones. ifname is the new parameter name.

Without this patch, the iface parameter was not found on ubuntu 18 and the command simply uses the first interface it found.

I am not sure that iface is used or not on ubuntu 16 and couldnt test it.